### PR TITLE
Migrate to bevy_egui 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy = { version = "0.16", default-features = false, features = [
 ] }
 clap = { version = "4.5", features = ["derive"] }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = { version = "0.34", default-features = false, features = [
+bevy_egui = { version = "0.35", default-features = false, features = [
     "render",
     "default_fonts",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_console"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 authors = ["RichoDemus <git@richodemus.com>"]
 homepage = "https://github.com/RichoDemus/bevy-console"

--- a/src/console.rs
+++ b/src/console.rs
@@ -496,7 +496,7 @@ pub(crate) fn console_ui(
     let keyboard_input_events = keyboard_input_events.read().collect::<Vec<_>>();
 
     // If there is no egui context, return, this can happen when exiting the app
-    let ctx = if let Some(ctxt) = egui_context.try_ctx_mut() {
+    let ctx = if let Ok(ctxt) = egui_context.ctx_mut() {
         ctxt
     } else {
         return;
@@ -765,7 +765,7 @@ pub fn block_mouse_input(
         return;
     }
 
-    let Some(context) = contexts.try_ctx_mut() else {
+    let Ok(context) = contexts.ctx_mut() else {
         return;
     };
 
@@ -783,7 +783,7 @@ pub fn block_keyboard_input(
         return;
     }
 
-    let Some(context) = contexts.try_ctx_mut() else {
+    let Ok(context) = contexts.ctx_mut() else {
         return;
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 use bevy::prelude::*;
 pub use bevy_console_derive::ConsoleCommand;
-use bevy_egui::{EguiContextPass, EguiPlugin, EguiPreUpdateSet};
+use bevy_egui::{EguiPlugin, EguiPreUpdateSet, EguiPrimaryContextPass};
 use console::{block_keyboard_input, block_mouse_input, ConsoleCache};
 use trie_rs::TrieBuilder;
 
@@ -86,14 +86,14 @@ impl Plugin for ConsolePlugin {
                     .before(EguiPreUpdateSet::BeginPass),
             )
             .add_systems(
-                EguiContextPass,
+                EguiPrimaryContextPass,
                 (
                     console_ui.in_set(ConsoleSet::ConsoleUI),
                     receive_console_line.in_set(ConsoleSet::PostCommands),
                 ),
             )
             .configure_sets(
-                EguiContextPass,
+                EguiPrimaryContextPass,
                 (
                     ConsoleSet::Commands
                         .after(ConsoleSet::ConsoleUI)
@@ -105,9 +105,7 @@ impl Plugin for ConsolePlugin {
         // Don't initialize an egui plugin if one already exists.
         // This can happen if another plugin is using egui and was installed before us.
         if !app.is_plugin_added::<EguiPlugin>() {
-            app.add_plugins(EguiPlugin {
-                enable_multipass_for_primary_context: true,
-            });
+            app.add_plugins(EguiPlugin::default());
         }
     }
 }


### PR DESCRIPTION
This PR consists of the necessary code changes to migrate to bevy_egui 0.35, to make this crate compatible with egui 0.35 users.

Please feel free to make any modifications as you see fit. Thank you!

### Changes
* Bumped `bevy_console` version to `0.15.0` in `Cargo.toml`.
* Updated `bevy_egui` dependency version from `0.34` to `0.35` in `Cargo.toml`.
* Replaced `try_ctx_mut` with `ctx_mut`.
* Replaced `EguiContextPass` with `EguiPrimaryContextPass`.
* Updated the `EguiPlugin` initialization to use `EguiPlugin::default()`